### PR TITLE
Update build skip condition to accept python 3.11

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
   sha256: 980313e642b0d5efcda7f37528d8ded2d28b577887122a9c1d4158cef61de058
 
 build:
-  skip: True  # [py<310 or py>310]
+  skip: True  # [py<310 or py>311]
   error_overlinking: false
   script: {{ PYTHON }} setup.py install
   number: 1
@@ -23,7 +23,9 @@ requirements:
     - {{ fortran_compiler }}
   host:
     - python
-    - setuptools
+    # limit setuptools version to avoid ModuleNotFoundError: No module named 'distutils.msvccompiler'
+    # when building the package
+    - setuptools <74
     - numpy
   run:
     - python


### PR DESCRIPTION
Update the build skip condition to allow installation next to python 3.11.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
